### PR TITLE
Show station names in train selection

### DIFF
--- a/src/lib/dateUtilities.ts
+++ b/src/lib/dateUtilities.ts
@@ -1,0 +1,10 @@
+export function formatShortFinnishTime(date: string) {
+  try {
+    return new Date(date).toLocaleTimeString("fi-FI", {
+      timeZone: "Europe/Helsinki",
+      timeStyle: "short",
+    });
+  } catch (e) {
+    return date;
+  }
+}

--- a/src/lib/vr.ts
+++ b/src/lib/vr.ts
@@ -1,5 +1,6 @@
 import { z } from "zod";
 import { getJSON, postJSON } from "~/lib/http";
+import { formatShortFinnishTime } from "./dateUtilities";
 
 function gql(strings: TemplateStringsArray, ...values: unknown[]) {
   return strings.reduce((v, i) => `${v}${String(values[parseInt(i)]) || ""}`);
@@ -151,4 +152,63 @@ export async function getStations() {
   const stations = Object.fromEntries(filteredData.map((s) => [s.stationShortCode, s.stationName]));
 
   return stations;
+}
+
+const trainsResponseSchema = z.array(
+  z.object({
+    trainNumber: z.number(),
+    trainType: z.string(),
+    timeTableRows: z.array(
+      z.object({
+        stationShortCode: z.string(),
+        scheduledTime: z.string(),
+      })
+    ),
+  })
+);
+
+export async function getInitialTrains(date: string) {
+  const [initialTrainsUnchecked, stations] = await Promise.all([
+    getJSON(`https://rata.digitraffic.fi/api/v1/trains/${date}`) as Promise<unknown>,
+    getStations(),
+  ]);
+
+  const initialTrains = trainsResponseSchema.parse(initialTrainsUnchecked);
+
+  return initialTrains
+    .filter((t) => ["IC", "S"].includes(t.trainType))
+    .map((t) => {
+      const departure = t.timeTableRows[0];
+      const arrival = t.timeTableRows[t.timeTableRows.length - 1];
+
+      if (!departure || !arrival) {
+        return {
+          value: t.trainNumber.toString(),
+          label: `${t.trainType}${t.trainNumber}`,
+          departureStationShortCode: "",
+          arrivalStationShortCode: "",
+          departureStationName: "",
+          arrivalStationName: "",
+        };
+      }
+
+      const departureTime = formatShortFinnishTime(departure.scheduledTime);
+      const arrivalTime = formatShortFinnishTime(arrival.scheduledTime);
+
+      const longDepartureStationName =
+        stations[departure.stationShortCode]?.replace("asema", "").trim() ??
+        departure.stationShortCode;
+      const longArrivalStationName =
+        stations[arrival.stationShortCode]?.replace("asema", "").trim() ?? arrival.stationShortCode;
+
+      return {
+        value: t.trainNumber.toString(),
+        label: `${t.trainType}${t.trainNumber} (${departure.stationShortCode} ${departureTime} -> ${arrival.stationShortCode} ${arrivalTime})`,
+        title: `${t.trainType}${t.trainNumber} (${longDepartureStationName} ${departureTime} -> ${longArrivalStationName} ${arrivalTime})`,
+        departureStationShortCode: departure.stationShortCode,
+        arrivalStationShortCode: arrival.stationShortCode,
+        departureStationName: stations[departure.stationShortCode] ?? departure.stationShortCode,
+        arrivalStationName: stations[arrival.stationShortCode] ?? arrival.stationShortCode,
+      };
+    });
 }


### PR DESCRIPTION
- Show short station name and scheduled time on the train selection dropdown. When hovering a row, it will show same, but with full station names

![image](https://github.com/Chicken/VenaaRauhassa/assets/38920928/16b8f052-6074-42be-a052-7bde498dd06e)

- Allow filtering by short/long station names:

![image](https://github.com/Chicken/VenaaRauhassa/assets/38920928/dcc65ed5-af12-4d0b-8b59-980c49a90f68)
![image](https://github.com/Chicken/VenaaRauhassa/assets/38920928/6f4e3ac7-732c-4af2-b4f8-ec8371364f25)
