### PR TITLE
Fix dropdown scrolling on iOS

### DIFF
--- a/src/components/TrainSelector.tsx
+++ b/src/components/TrainSelector.tsx
@@ -86,6 +86,8 @@ export const TrainSelector: React.FC<TrainSelectorProps> = ({
         filterSort={(optionA, optionB) =>
           parseInt(String(optionA.value ?? 0)) - parseInt(String(optionB.value ?? 0))
         }
+        virtual={false}
+        dropdownRender={(menu) => <div style={{ height: 250, overflow: "auto" }}>{menu}</div>}
         options={allTrains}
       />
 

--- a/src/styles/global.css
+++ b/src/styles/global.css
@@ -19,6 +19,11 @@ body {
   box-shadow: 0 0 0 2px var(--handle-color) !important;
 }
 
+.rc-virtual-list-holder {
+  max-height: unset !important;
+  overflow-y: unset !important;
+}
+
 .layoutPadding {
   padding: 50px 50px 20px 50px;
   @media (max-width: 768px) {
@@ -43,7 +48,7 @@ body {
   flex-grow: 1;
 }
 
-.frontpage .header{
+.frontpage .header {
   display: flex;
   flex-direction: column;
   align-items: center;
@@ -62,7 +67,6 @@ body {
   width: 100%;
   text-align: center;
 }
-
 
 /* Wahonmap */
 .wagonClass {


### PR DESCRIPTION
Before this change, if you opened the train selector dropdown on iOS, it would occasionally scroll the whole page instead of the dropdown. Now it should only ever scroll the dropdown.

Fix from: https://github.com/ant-design/ant-design/issues/37674#issuecomment-2661170295