### PR TITLE
Use maxHeight instead of height for train selector

### DIFF
--- a/src/components/TrainSelector.tsx
+++ b/src/components/TrainSelector.tsx
@@ -87,7 +87,7 @@ export const TrainSelector: React.FC<TrainSelectorProps> = ({
           parseInt(String(optionA.value ?? 0)) - parseInt(String(optionB.value ?? 0))
         }
         virtual={false}
-        dropdownRender={(menu) => <div style={{ height: 250, overflow: "auto" }}>{menu}</div>}
+        dropdownRender={(menu) => <div style={{ maxHeight: 250, overflow: "auto" }}>{menu}</div>}
         options={allTrains}
       />
 


### PR DESCRIPTION
Fixes bug where train selector was too tall when filtering trains